### PR TITLE
Setup Postgres HA nodes with etcd and Patroni

### DIFF
--- a/inventory/hosts.yml
+++ b/inventory/hosts.yml
@@ -5,3 +5,13 @@ all:
       ansible_user: vagrant
       ansible_ssh_private_key_file: .vagrant/machines/default/virtualbox/private_key
       ansible_ssh_extra_args: '-o StrictHostKeyChecking=no'
+
+postgres_nodes:
+  hosts:
+    192.168.122.156:
+    192.168.122.225:
+    192.168.122.171:
+
+postgres_proxy:
+  hosts:
+    192.168.122.172:

--- a/playbooks/001-setup-postgres-nodes.yml
+++ b/playbooks/001-setup-postgres-nodes.yml
@@ -1,0 +1,62 @@
+- name: Install PostgreSQL 16 server on all hosts
+  hosts: postgres_nodes
+  become: yes
+  tasks:
+    - name: Install PostgreSQL 16
+      yum:
+        name: postgresql16-server
+        state: present
+
+    - name: Set /etc/hosts file
+      lineinfile:
+        path: /etc/hosts
+        line: "{{ item }}"
+      with_items:
+        - "192.168.122.156 postgres-node-1"
+        - "192.168.122.225 postgres-node-2"
+        - "192.168.122.171 postgres-node-3"
+
+    - name: Install etcd
+      yum:
+        name: etcd
+        state: present
+
+    - name: Configure etcd
+      template:
+        src: etcd.conf.j2
+        dest: /etc/etcd/etcd.conf
+      notify: restart etcd
+
+    - name: Start and enable etcd
+      systemd:
+        name: etcd
+        state: started
+        enabled: yes
+
+    - name: Install Patroni
+      yum:
+        name: patroni
+        state: present
+
+    - name: Configure Patroni
+      template:
+        src: patroni.yml.j2
+        dest: /etc/patroni.yml
+      notify: restart patroni
+
+    - name: Start and enable Patroni
+      systemd:
+        name: patroni
+        state: started
+        enabled: yes
+
+  handlers:
+    - name: restart etcd
+      systemd:
+        name: etcd
+        state: restarted
+
+    - name: restart patroni
+      systemd:
+        name: patroni
+        state: restarted

--- a/playbooks/001-setup-postgres-nodes.yml
+++ b/playbooks/001-setup-postgres-nodes.yml
@@ -50,6 +50,30 @@
         state: started
         enabled: yes
 
+    - name: Ensure SELinux is enforcing
+      command: setenforce 1
+
+    - name: Allow PostgreSQL service in firewall
+      firewalld:
+        service: postgresql
+        permanent: yes
+        state: enabled
+        immediate: yes
+
+    - name: Allow etcd service in firewall
+      firewalld:
+        service: etcd
+        permanent: yes
+        state: enabled
+        immediate: yes
+
+    - name: Allow Patroni service in firewall
+      firewalld:
+        service: patroni
+        permanent: yes
+        state: enabled
+        immediate: yes
+
   handlers:
     - name: restart etcd
       systemd:

--- a/templates/etcd.conf.j2
+++ b/templates/etcd.conf.j2
@@ -1,0 +1,15 @@
+# etcd configuration file
+
+name: "{{ ansible_hostname }}"
+data-dir: /var/lib/etcd
+wal-dir: /var/lib/etcd/wal
+snapshot-count: 10000
+heartbeat-interval: 100
+election-timeout: 1000
+listen-peer-urls: http://{{ ansible_hostname }}:2380
+listen-client-urls: http://{{ ansible_hostname }}:2379,http://127.0.0.1:2379
+initial-advertise-peer-urls: http://{{ ansible_hostname }}:2380
+advertise-client-urls: http://{{ ansible_hostname }}:2379
+initial-cluster-token: etcd-cluster-1
+initial-cluster: "postgres-node-1=http://192.168.122.156:2380,postgres-node-2=http://192.168.122.225:2380,postgres-node-3=http://192.168.122.171:2380"
+initial-cluster-state: new

--- a/templates/patroni.yml.j2
+++ b/templates/patroni.yml.j2
@@ -1,0 +1,72 @@
+scope: postgres
+namespace: /service/
+name: {{ ansible_hostname }}
+
+restapi:
+  listen: {{ ansible_hostname }}:8008
+  connect_address: {{ ansible_hostname }}:8008
+
+etcd:
+  host: 192.168.122.156:2379,192.168.122.225:2379,192.168.122.171:2379
+
+bootstrap:
+  dcs:
+    ttl: 30
+    loop_wait: 10
+    retry_timeout: 10
+    maximum_lag_on_failover: 1048576
+    postgresql:
+      use_pg_rewind: true
+      use_slots: true
+  initdb:
+    - encoding: UTF8
+    - data-checksums
+
+postgresql:
+  listen: {{ ansible_hostname }}:5432
+  connect_address: {{ ansible_hostname }}:5432
+  data_dir: /var/lib/postgresql/data
+  bin_dir: /usr/pgsql-16/bin
+  config_dir: /etc/postgresql/16/main
+  pgpass: /tmp/pgpass
+  authentication:
+    superuser:
+      username: postgres
+      password: postgres
+    replication:
+      username: replicator
+      password: replicator
+  parameters:
+    max_connections: 100
+    max_locks_per_transaction: 64
+    max_worker_processes: 8
+    wal_level: replica
+    hot_standby: "on"
+    wal_keep_segments: 8
+    max_wal_senders: 5
+    max_replication_slots: 5
+    archive_mode: "on"
+    archive_command: 'test ! -f /var/lib/postgresql/data/archive/%f && cp %p /var/lib/postgresql/data/archive/%f'
+    archive_timeout: 1800s
+    synchronous_commit: "on"
+    synchronous_standby_names: '*'
+    log_destination: 'csvlog'
+    logging_collector: "on"
+    log_directory: '/var/log/postgresql'
+    log_filename: 'postgresql-%a.log'
+    log_file_mode: '0640'
+    log_rotation_age: '1d'
+    log_rotation_size: '100MB'
+    log_min_duration_statement: 500
+    log_checkpoints: "on"
+    log_connections: "on"
+    log_disconnections: "on"
+    log_lock_waits: "on"
+    log_statement: 'ddl'
+    log_temp_files: 0
+    track_io_timing: "on"
+    track_functions: 'all'
+    track_activity_query_size: 2048
+    track_commit_timestamp: "on"
+    track_counts: "on"
+    track_activities: "on"


### PR DESCRIPTION
Modify the `inventory/hosts.yml` file to include the specified hosts in the 'postgres_nodes' and 'postgres_proxy' groups.

* Add the 'postgres_nodes' group with hosts 192.168.122.156, 192.168.122.225, and 192.168.122.171.
* Add the 'postgres_proxy' group with host 192.168.122.172.

Modify the `playbooks/001-setup-postgres-nodes.yml` file to set up PostgreSQL, etcd, and Patroni on the 'postgres_nodes' group.

* Add a play to install PostgreSQL 16 server on all hosts in the 'postgres_nodes' group.
* Add a task to set the `/etc/hosts` file to link each host to its respective name.
* Add tasks to install and configure etcd on the 'postgres_nodes' group with peer configuration.
* Add tasks to install and configure Patroni on the 'postgres_nodes' group with peer configuration.

Add the `templates/etcd.conf.j2` file for the etcd configuration.

Add the `templates/patroni.yml.j2` file for the Patroni configuration and remove duplicate PostgreSQL parameters.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/sayyidyofa/Postgres-HA-PoC/pull/1?shareId=c539f5de-8028-4ebf-9bcd-62814256f671).